### PR TITLE
Add optional IPv6 support for Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ make docker
 | DOCKERHUB_REPO_IMAGE |         ratelimitpreview/test         |        custom repository/image        |
 | ENABLE_FILE_AUTH |         false         |        Load auth credentials from docker config file<br>at /$FILE_AUTH_DIR/config.json<br>Must leave auth through ENV empty.       |
 | FILE_AUTH_DIR |         /config         |        Directory where config.json resides       |
+| ENABLE_IPV6   |         false           | Use IPv6 instead of IPv4 when fetching rate limits |
 <br>
 
 Example docker configuration config.json file below. <br>

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -29,9 +29,17 @@ var DockerLabels = make(map[string]string, 1)
 // GetMetrics will save metrics in a float64 map
 func GetMetrics() {
 	l := log.New(os.Stdout, "drl-exporter ", log.LstdFlags)
-	tokenUrl := "https://auth.docker.io/token?service=" +
+
+	tokenBaseUrl := "https://auth.docker.io"
+	repoBaseUrl := "https://registry-1.docker.io"
+	if *vars.EnableIPv6 {
+		tokenBaseUrl = "https://auth.ipv6.docker.com"
+		repoBaseUrl = "https://registry.ipv6.docker.com"
+	}
+
+	tokenUrl := tokenBaseUrl + "/token?service=" +
 		"registry.docker.io&scope=repository:" + *vars.DockerRepoImage + ":pull"
-	repoUrl := "https://registry-1.docker.io/v2/" +
+	repoUrl := repoBaseUrl + "/v2/" +
 		"registry.docker.io&scope=repository:" + *vars.DockerRepoImage + "/manifests/latest"
 
 	tr, err := tokenRequest(tokenUrl)

--- a/internal/vars/envars.go
+++ b/internal/vars/envars.go
@@ -12,4 +12,5 @@ var (
 	EnableUserAuth  = env.Bool("ENABLE_USER_AUTH", false, false, "Enable metrics for users")
 	EnableFileAuth  = env.Bool("ENABLE_FILE_AUTH", false, false, "Enable authentication through docker configuration file 'config.json'")
 	FileAuthDir     = env.String("FILE_AUTH_DIR", false, "/config", "Directory to load 'config.json' docker configuration from")
+	EnableIPv6      = env.Bool("ENABLE_IPV6", false, false, "Use IPv6 instead of IPv4")
 )


### PR DESCRIPTION
# Description

This PR adds optional support for IPv6 rate limits, by adding an `ENABLE_IPV6` environment variable. If set to `1`, it will send requests over IPv6 instead of over IPv4.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

If you have any suggestions for unit tests, please tell me, but since no tests existed for the IPv4 path, I did not add any for the IPv6 changes.

Tested by running on an IPv6 enabled node, like below (part of my IPv6 address censored with `xxxx`):

```
ENABLE_IPV6=1 ./drl-exporter
2023/03/28 11:53:33 DRL exporter Version , Commit , BuildDate
2023/03/28 11:53:33 Starting server on port 2121

$ curl http://localhost:2121/metrics
# HELP dockerhub_limit_max_requests_time Dockerhub rate limit maximum requests total time seconds
# TYPE dockerhub_limit_max_requests_time gauge
dockerhub_limit_max_requests_time{reqsource="2a01:4f9:c010:xxxx::"} 21600
# HELP dockerhub_limit_max_requests_total Dockerhub rate limit maximum requests in given time
# TYPE dockerhub_limit_max_requests_total gauge
dockerhub_limit_max_requests_total{reqsource="2a01:4f9:c010:xxxx::"} 100
# HELP dockerhub_limit_remaining_requests_time Dockerhub rate limit remaining requests time seconds
# TYPE dockerhub_limit_remaining_requests_time gauge
dockerhub_limit_remaining_requests_time{reqsource="2a01:4f9:c010:xxxx::"} 21600
# HELP dockerhub_limit_remaining_requests_total Dockerhub rate limit remaining requests in given time
# TYPE dockerhub_limit_remaining_requests_total gauge
dockerhub_limit_remaining_requests_total{reqsource="2a01:4f9:c010:xxxx::"} 98
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.1
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 9
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 1.3340672e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.67999721271e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 7.36137216e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 3
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

- [x] Running existing tests
- [ ] Created new tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
